### PR TITLE
added prompt tempate files to /config directory

### DIFF
--- a/src/simulation/config/prompt-template/service-agent-prompt-template.ts
+++ b/src/simulation/config/prompt-template/service-agent-prompt-template.ts
@@ -1,0 +1,1 @@
+// Langchain prompt template class for service agent (more can be added) to easily fetch/prepare relevant prompts

--- a/src/simulation/config/prompt-template/user-agent-prompt-template.ts
+++ b/src/simulation/config/prompt-template/user-agent-prompt-template.ts
@@ -1,0 +1,1 @@
+// Langchain prompt template class for user agent to easily fetch/prepare relevant prompts


### PR DESCRIPTION
Since LangChain offers some prompt templates, we could include them in a class to easily form/fetch prompts for the agents to use.

More service agent prompt template classes could be added, or a single class could be utilized for service agents for different objectives - with a simple switch logic