### PR TITLE
store hangup message in db

### DIFF
--- a/src/simulation/db/enum/enums.ts
+++ b/src/simulation/db/enum/enums.ts
@@ -42,6 +42,7 @@ enum MsgTypes {
   TOOLOUTPUT = 'TOOLOUTPUT',
   MSGTOUSER = 'MSGTOUSER',
   ROUTE = 'ROUTE',
+  HANGUP = 'HANGUP',
 }
 
 enum MsgSender {


### PR DESCRIPTION
Hangup message is stored in db, text is "/hangup" and I added a new MsgType in the Enum thats called Hangup, so it's even easier for the evaluation team to check if the conversation ended successfully