### PR TITLE
set presona of agents individually

### DIFF
--- a/src/simulation/agents/user.agent.ts
+++ b/src/simulation/agents/user.agent.ts
@@ -87,13 +87,17 @@ const TOOL_OUTPUT_TEMPLATE = `# RESULT FROM '{toolName}' TOOL
  * @throws Error if the persona is not found in the available personas.
  */
 export function getSimConfig(persona: string): CustomAgentConfig {
-  if (!(persona in PERSONAS)) {
-    throw new Error(`Persona ${persona} not found. Available personas: ${Object.keys(PERSONAS)}`);
+  let convertedPersona: string;
+  if (persona in PERSONAS) {
+    convertedPersona = PERSONAS[persona];
+  } else {
+    convertedPersona = persona;
+    //throw new Error(`Persona ${persona} not found. Available personas: ${Object.keys(PERSONAS)}`);
   }
   const personaConfig = new CustomAgentConfig();
   personaConfig.temperature = TEMPERATURE;
   personaConfig.role = ROLE;
-  personaConfig.persona = PERSONAS[persona];
+  personaConfig.persona = convertedPersona;
   personaConfig.conversationStrategy = CONVERSATION_STRATEGY;
   personaConfig.systemPromptTemplate = SYSTEM_PROMPT_TEMPLATE;
   personaConfig.humanInputTemplate = HUMAN_INPUT_TEMPLATE;

--- a/src/simulation/service/conversation.service.ts
+++ b/src/simulation/service/conversation.service.ts
@@ -227,6 +227,14 @@ export async function configureServiceAgent(
     agentLLM = new ChatOpenAI(azureOpenAIInput);
   }
 
+  if (agentData.prompt !== 'default') {
+    flightBookingAgentConfig.persona = agentData.prompt;
+  } else {
+    flightBookingAgentConfig.persona = `- You should be empathetic, helpful, comprehensive and polite.
+    - Never use gender specific prefixes like Mr. or Mrs. when addressing the user unless they used it themselves.
+    `;
+  }
+
   const serviceAgent: CustomAgent = new CustomAgent(
     agentLLM,
     flightBookingAgentConfig,


### PR DESCRIPTION
The user is now able to set the persona of the agents individually with the "prompt" parameter in the agentConfigs. 
Their are different possibilities:

User Agent:
1. You can still use "nonative", "sarcastic" etc. and the persona gets mapped accordingly
2. If you don't use one of the predefined personas, the text is directly used as the persona

Service Agent:
1. With "default" you use the default persona that we had until now
2. Any other string gets directly used as persona