### PR TITLE
Start a Chat with Agent Config or ID

### DIFF
--- a/src/simulation/model/request/chat.request.ts
+++ b/src/simulation/model/request/chat.request.ts
@@ -1,8 +1,10 @@
+import { AgentDocument } from '@db/models/agent.model';
 import { Types } from 'mongoose';
 
 interface StartChatRequest {
   name: string;
-  agent: Types.ObjectId;
+  agentId?: Types.ObjectId;
+  agentConfig?: AgentDocument;
 }
 
 export { StartChatRequest };

--- a/src/simulation/service/chat.service.ts
+++ b/src/simulation/service/chat.service.ts
@@ -32,14 +32,21 @@ async function start(config: StartChatRequest): Promise<SimulationDocument> {
   const simulation: SimulationDocument = new SimulationModel();
 
   simulation.name = config.name;
-  simulation.serviceAgent = config.agent;
   simulation.status = SimulationStatus.RUNNING;
   simulation.type = SimulationType.CHAT;
 
   let serviceAgentModel: AgentDocument | null = null;
-  if (config.agent) {
-    serviceAgentModel = await agentRepository.getById(config.agent.toString());
+  if (config.agentConfig !== undefined) {
+    serviceAgentModel = await agentRepository.create(config.agentConfig!);
+  } else if (config.agentId !== undefined) {
+    serviceAgentModel = await agentRepository.getById(config.agentId!.toString());
   }
+
+  if (serviceAgentModel === null) {
+    throw new Error('Agent id not found');
+  }
+
+  simulation.serviceAgent = serviceAgentModel;
 
   if (serviceAgentModel) {
     serviceAgent = await configureServiceAgent(serviceAgentModel);

--- a/src/simulation/validator/chat.validator.ts
+++ b/src/simulation/validator/chat.validator.ts
@@ -8,10 +8,23 @@ class ChatValidator {
   static runValidation(): ValidationChain[] {
     return [
       body('name').isString().withMessage('Name must be a valid string.'),
-      body('agent').isMongoId().withMessage('Service agent id must be a valid Mongo id.'),
+      body('agentId').optional().isMongoId().withMessage('Agent id must be a valid Mongo id.'),
+      body('agentConfig').optional().isObject().withMessage('Agent config must be a valid object.'),
+
+      body().custom((value) => {
+        if (value.agentId && value.agentConfig) {
+          throw new Error('Cannot have agentConfig and agentId at the same time.');
+        }
+
+        if (!value.agentId && !value.agentConfig) {
+          throw new Error('Must have agentConfig or agentId.');
+        }
+
+        return true;
+      }),
 
       body().custom((value, { req }) => {
-        const allowedFields = ['name', 'agent'];
+        const allowedFields = ['name', 'agentId', 'agentConfig'];
 
         const extraFields = Object.keys(req.body).filter((field) => !allowedFields.includes(field));
 


### PR DESCRIPTION
- Added functionality to initiate a chat by providing either the agent configuration or the agent ID
- Updated API input validation for /chat/start endpoint