### PR TITLE
Update JEST to support ECMA

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@
 export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  transform: {},
   moduleNameMapper: {
     '^@simulation/agents/(.*)$': '<rootDir>/src/simulation/agents/$1',
     '^@simulation/api/(.*)$': '<rootDir>/src/simulation/api/$1',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:dev": "tsx watch src",
     "build": "rimraf ./build && tsc && tsc-alias",
     "start": "npm run build && node build/src/index.js",
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "jest --watch",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Even after the JEST fix by @weirdkey, I was getting the weird parser error for tests. 

After some digging, turned out that Jest only recently started supporting the ES modules, which we use instead of `commonJS`. Note that **this is still experimental, but should work fine for our case**.

Please see here for more details: https://jestjs.io/docs/ecmascript-modules