### PR TITLE
Update Dockerfile to use Node:bullseye base image, add python functionality to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install -y \
 COPY requirements.txt ./
 
 # Install Python dependencies
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements.txt && \
+    python3 -m spacy download en_core_web_sm
 
 # Copy the rest of your app's source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,34 @@
-FROM node:alpine
+# Start with the Node.js slim base image
+FROM node:bullseye-slim
 
-# Set the working directory inside the container
+# Set the working directory
 WORKDIR /usr/src/app
 
-# Copy package.json and package-lock.json
+# Copy package.json and package-lock.json for Node.js dependencies
 COPY package*.json ./
 
+# Install Node.js dependencies
 RUN npm install --legacy-peer-deps
 
+# Install Python and pip
+# Update the package lists and install Python and pip
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the Python requirements file
+COPY requirements.txt ./
+
+# Install Python dependencies
+RUN pip3 install -r requirements.txt
+
+# Copy the rest of your app's source code
 COPY . .
 
-# Expose the port
+# Build your TypeScript files
+RUN npm run build
+
+# The application's port
 EXPOSE 3000
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+spacy
+spacytextblob
+nltk
+python-dateutil

--- a/src/simulation/service/conversation.service.ts
+++ b/src/simulation/service/conversation.service.ts
@@ -416,7 +416,7 @@ export async function runConversation(
   const messages: MessageDocument[] = [];
   for (let i = 0; i < serviceAgent.messageHistory.length; i++) {
     messages.push(
-      await createMessageDocument(serviceAgent.messageHistory[i], serviceAgent.config.welcomeMessage, usedEndpoints),
+      await createMessageDocument(serviceAgent.messageHistory[i], usedEndpoints, serviceAgent.config.welcomeMessage),
     );
   }
   if (conversationSuccess) {


### PR DESCRIPTION
Solves: https://linear.app/parloa-ws2324/issue/PAR-176/[meta]-hotfix-add-python-modules-for-evaluation

Base image changed from `Alpine `to `node:bullseye-slim`, which is based on Debian and therefore uses `glibc` so we don't have to install every single C dependency and finally can use pre-existing wheels.

It took nearly 25 mins to do everthing with Alpine, and with the current base image, when everything is cached (the python stuff, mainly) it took my computer 45 seconds to build the image, which is a decent time gain 🤯 Our image size is now 1.17 GB, and I think it was around 550MB with Alpine, so there is a tradeoff to be made here for sure. 

**Question for reviewers**

- Especially @amyjchao please try this and let me know if your scripts work, I have not tried to make them work. I only made sur that the code did not break.
- @ardaakcabuyuk Very simple fix for the conversation.service.ts.
- Also feel free to let me know if you know any base images that would be more suitable to our case, I would be grateful. 