### PR TITLE
Reload idle chat sessions when a message is sent

### DIFF
--- a/src/simulation/api/chat.controller.ts
+++ b/src/simulation/api/chat.controller.ts
@@ -38,7 +38,7 @@ async function load(req: Request, res: Response): Promise<void> {
     const chat: SimulationDocument | null = await simulationService.poll(chatId);
     if (chat) {
       console.log('Loading chat...');
-      const messages: ChatMessage[] = await chatService.load(chatId);
+      const { messages } = await chatService.load(chatId);
       res.status(200).send(messages);
     } else {
       res.status(404).send({ error: `Chat ${chatId} not found!` });

--- a/src/simulation/service/agent.manager.service.ts
+++ b/src/simulation/service/agent.manager.service.ts
@@ -49,7 +49,7 @@ class AgentManager {
    * @param chatId - ID of the chat.
    * @returns The agent for the specified simulation or null if none found.
    */
-  getAgentByConversation(chatId: string): CustomAgent | null {
+  getAgentBySimulation(chatId: string): CustomAgent | null {
     return this.agents.get(chatId) || null;
   }
 

--- a/src/simulation/service/chat.service.ts
+++ b/src/simulation/service/chat.service.ts
@@ -12,6 +12,7 @@ import { createMessageDocument } from '@simulation/service/conversation.service'
 import ChatMessage from '@simulation/model/response/chat.response';
 import { StartChatRequest } from '@simulation/model/request/chat.request';
 import AgentManager from '@simulation/service/agent.manager.service';
+import { CustomAgent } from '@simulation/agents/custom.agent';
 
 const agentRepository = repositoryFactory.agentRepository;
 const chatRepository = repositoryFactory.chatRepository;
@@ -25,12 +26,13 @@ const agentManager = new AgentManager();
  * @returns A promise that resolves to the chat simulation object.
  */
 async function start(config: StartChatRequest): Promise<SimulationDocument> {
+  // Create a new simulation
   const simulation: SimulationDocument = new SimulationModel();
-
   simulation.name = config.name;
   simulation.status = SimulationStatus.RUNNING;
   simulation.type = SimulationType.CHAT;
 
+  // Get or create the service agent document
   let serviceAgentModel: AgentDocument | null = null;
   if (config.agentConfig !== undefined) {
     config.agentConfig.temporary = true;
@@ -46,6 +48,7 @@ async function start(config: StartChatRequest): Promise<SimulationDocument> {
   simulation.serviceAgent = serviceAgentModel;
 
   if (serviceAgentModel) {
+    // Create a new agent for the chat
     const chat: SimulationDocument = await chatRepository.create(simulation);
 
     const usedEndpoints: string[] = [];
@@ -85,10 +88,23 @@ async function start(config: StartChatRequest): Promise<SimulationDocument> {
 async function sendMessage(chatId: string, message: string): Promise<ChatMessage> {
   const usedEndpoints: string[] = [];
 
-  // Set the current agent for processing the message
-  const agent = agentManager.getAgentByConversation(chatId);
+  // Get the agent
+  let agent = agentManager.getAgentBySimulation(chatId);
+
+  // If the agent doesn't exist, load/initialize it
+  if (!agent) {
+    const { agent: loadedAgent } = await load(chatId);
+
+    // Use the loaded agent
+    if (loadedAgent) {
+      agent = loadedAgent;
+    } else {
+      throw new Error(`Failed to load the agent for chatId: ${chatId}`);
+    }
+  }
 
   if (agent) {
+    // Process the user's message and update the conversation
     const agentResponse = await agent.processHumanInput(message);
 
     let messageCount = agentManager.getMessageCountForCurrentAgent(chatId);
@@ -100,6 +116,7 @@ async function sendMessage(chatId: string, message: string): Promise<ChatMessage
     await chatRepository.send(chatId, userMessage);
     agentManager.incrementMessageCountForCurrentAgent(chatId);
 
+    // Process agent responses and update the conversation
     let agentMessage: MessageDocument = {} as MessageDocument;
     messageCount = agentManager.getMessageCountForCurrentAgent(chatId);
     while (messageCount < agent.messageHistory.length) {
@@ -109,6 +126,7 @@ async function sendMessage(chatId: string, message: string): Promise<ChatMessage
       messageCount = agentManager.getMessageCountForCurrentAgent(chatId);
     }
 
+    // Prepare the response message to be sent to the user
     const response: ChatMessage = {
       sender: agentMessage.sender,
       // text: agentMessage.msgToUser ? agentMessage.msgToUser : '',
@@ -128,9 +146,11 @@ async function sendMessage(chatId: string, message: string): Promise<ChatMessage
  * @param id - Simulation id
  * @returns A promise that resolves to the chat simulation object.
  */
-async function load(chatId: string): Promise<ChatMessage[]> {
+async function load(chatId: string): Promise<{ messages: ChatMessage[]; agent: CustomAgent | null }> {
   const messages: ChatMessage[] = [];
+  let agent: CustomAgent | null = null;
 
+  // Load chat history from the database
   const [agentId, msgHistory] = await chatRepository.loadChat(chatId);
 
   let serviceAgentModel: AgentDocument | null = null;
@@ -143,7 +163,7 @@ async function load(chatId: string): Promise<ChatMessage[]> {
     await agentManager.createAgent(chatId, serviceAgentModel, msgHistory);
 
     // Retrieve the current agent and load the chat history
-    const agent = agentManager.getCurrentAgent(chatId);
+    agent = agentManager.getCurrentAgent(chatId);
     if (agent) {
       for (let i = 0; i < agent.messageHistory.length; i++) {
         if (agent.messageHistory[i].type === MsgType.HUMANINPUT) {
@@ -155,7 +175,11 @@ async function load(chatId: string): Promise<ChatMessage[]> {
         }
 
         const msgToUser = agent.messageHistory[i].msgToUser;
+        const intermediateMsg = agent.messageHistory[i].intermediateMsg;
         const timestamp = agent.messageHistory[i].timestamp;
+        if (intermediateMsg !== null) {
+          messages.push({ sender: MsgSender.AGENT, text: intermediateMsg, timestamp: timestamp, userCanReply: true });
+        }
         if (msgToUser !== null) {
           messages.push({ sender: MsgSender.AGENT, text: msgToUser, timestamp: timestamp, userCanReply: true });
         }
@@ -166,7 +190,7 @@ async function load(chatId: string): Promise<ChatMessage[]> {
     agentManager.loadMessageCountForCurrentAgent(chatId);
   }
 
-  return messages;
+  return { messages, agent };
 }
 
 /**


### PR DESCRIPTION
- Added a check for the existence of the agent with the specified ID in the global agent map when /chat/:id/send-message is called.
- If the agent is not found, the load() function is called with the provided ID to initialize the agent.