### PR TITLE
Feature/par 223 eva fix bugs in response time and recovery rate metrics

### DIFF
--- a/src/evaluation/service/evaluation.recovery.py
+++ b/src/evaluation/service/evaluation.recovery.py
@@ -23,7 +23,8 @@ def recovery_counter(texts, delta):
     recovering = False
     recoveries = 0
     for m in texts:
-        if m['sender'].lower() == 'USER'.lower() and not find_response(texts, delta, m['timestamp']):
+        # only consider user messages except the HANGUP message
+        if m['sender'].lower() == 'USER'.lower() and m['type'].lower() != 'HANGUP'.lower() and not find_response(texts, delta, m['timestamp']):
             timeouts += 1
             recovering = True
         else:

--- a/src/evaluation/service/metric.service.ts
+++ b/src/evaluation/service/metric.service.ts
@@ -139,10 +139,6 @@ function calculateAverageResponseTime(
 ): number {
   const filteredMessages = messages.filter((message) => message.sender !== MsgSender.TOOL); // Filter out api call messages
 
-  if (filteredMessages.length < 2) {
-    return 0;
-  }
-
   let totalResponseTimeOfAgent = 0;
   let countAgentMessages = 0;
 
@@ -158,6 +154,11 @@ function calculateAverageResponseTime(
     const responseTime = currentMessage.timestamp.getTime() - prevMessage.timestamp.getTime();
     totalResponseTimeOfAgent += responseTime;
     countAgentMessages++;
+  }
+
+  if (countAgentMessages == 0) {
+    // agent didn't respond at all
+    return Number.MAX_VALUE;
   }
 
   return totalResponseTimeOfAgent / countAgentMessages;

--- a/src/evaluation/service/metric.service.ts
+++ b/src/evaluation/service/metric.service.ts
@@ -145,6 +145,10 @@ function calculateAverageResponseTime(
   for (let i = 1; i < filteredMessages.length; i++) {
     const currentMessage = filteredMessages[i];
 
+    if (filteredMessages.length < 2) {
+      return 0;
+    }
+
     // Only calculate response time for agent messages
     if (currentMessage.sender === MsgSender.USER) {
       continue;

--- a/src/evaluation/service/metric.service.ts
+++ b/src/evaluation/service/metric.service.ts
@@ -139,15 +139,15 @@ function calculateAverageResponseTime(
 ): number {
   const filteredMessages = messages.filter((message) => message.sender !== MsgSender.TOOL); // Filter out api call messages
 
+  if (filteredMessages.length < 2) {
+    return 0;
+  }
+
   let totalResponseTimeOfAgent = 0;
   let countAgentMessages = 0;
 
   for (let i = 1; i < filteredMessages.length; i++) {
     const currentMessage = filteredMessages[i];
-
-    if (filteredMessages.length < 2) {
-      return 0;
-    }
 
     // Only calculate response time for agent messages
     if (currentMessage.sender === MsgSender.USER) {


### PR DESCRIPTION
Fixed two bugs:

1. Response time metrics:
When the agent didn't respond at all (except the initial welcome message), a division through 0 could occur, leading to a 500 Internal Server Error (because NaN isn't accepted as value of type Number in the database).

2. Recovery rate metrics:
The HANGUP message at the end was always counted as timeout (because the agent didn't respond to that message), leading to wrong scores. Especially conversations without timeout got score 0 instead of 1.