### PR TITLE
[Eva] adjust csv export to consider failed simulations

### DIFF
--- a/src/evaluation/api/evaluation.controller.ts
+++ b/src/evaluation/api/evaluation.controller.ts
@@ -60,7 +60,7 @@ async function runMultiple(req: Request, res: Response): Promise<void> {
     }
 
     const evaluationConfig: RunMultipleEvaluationsRequest = req.body as RunMultipleEvaluationsRequest;
-    const evaluationResults: EvaluationExecutedWithConversation[] =
+    const evaluationResults: (EvaluationExecutedWithConversation | null)[] =
       await evaluationService.runMultipleEvaluations(evaluationConfig);
     const csvFile = evaluationResultsToCsv(evaluationResults);
     res.download(...csvFile);

--- a/src/evaluation/service/evaluation.service.ts
+++ b/src/evaluation/service/evaluation.service.ts
@@ -67,8 +67,8 @@ async function runEvaluation(request: RunEvaluationRequest): Promise<RunEvaluati
  */
 async function runMultipleEvaluations(
   request: RunMultipleEvaluationsRequest,
-): Promise<EvaluationExecutedWithConversation[]> {
-  const promises: Promise<Promise<EvaluationExecutedWithConversation>[]>[] = request.simulations.map(
+): Promise<(EvaluationExecutedWithConversation | null)[]> {
+  const promises: Promise<Promise<EvaluationExecutedWithConversation>[] | null>[] = request.simulations.map(
     async (simulationID) => {
       const simulation: SimulationDocument | null = await simulationService.poll(simulationID);
 
@@ -77,6 +77,11 @@ async function runMultipleEvaluations(
       }
 
       const conversations = (await simulation.populate('conversations')).conversations as ConversationDocument[];
+
+      // simulation failed
+      if (conversations.length !== 1) {
+        return null;
+      }
 
       return conversations.map(async (conversation, indx) => {
         const runRequest: RunEvaluationRequest = {

--- a/src/evaluation/utils/results-to-csv.ts
+++ b/src/evaluation/utils/results-to-csv.ts
@@ -11,7 +11,7 @@ const CELL_SEPARATOR = ',';
  * @param results - The results which should be stored in the csv file
  * @returns an array with the path to the created file as first and the filename as second element
  */
-function evaluationResultsToCsv(results: EvaluationExecutedWithConversation[]): [string, string] {
+function evaluationResultsToCsv(results: (EvaluationExecutedWithConversation | null)[]): [string, string] {
   const filePath = path.join(EVALUATION_RESULTS_DIR, `evaluation-results_${getFormattedDate()}.csv`);
 
   if (!fs.existsSync(path.dirname(filePath))) {
@@ -27,7 +27,11 @@ function evaluationResultsToCsv(results: EvaluationExecutedWithConversation[]): 
   lines.push(data.join(CELL_SEPARATOR));
 
   for (const result of results) {
-    lines.push(generateTableRow(result));
+    if (result) {
+      lines.push(generateTableRow(result));
+    } else {
+      lines.push('-');
+    }
   }
 
   fs.writeFileSync(filePath, lines.join('\n'));


### PR DESCRIPTION
Adjust CSV export: if a simulation failes, it is not silently ignored anymore; instead, it is marked with "-" in the generated CSV file.